### PR TITLE
UUID to string

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - api.env
 
   mysql:
-    image: mysql
+    image: mysql:5.5.59
     environment:
       MYSQL_ROOT_PASSWORD: password
       MYSQL_DATABASE: heretohelp

--- a/src/main/java/org/dsmhack/controller/LoginController.java
+++ b/src/main/java/org/dsmhack/controller/LoginController.java
@@ -36,6 +36,6 @@ public class LoginController {
     @PostMapping("/login/verifyCode")
     public User verifyCode(@RequestBody String securityToken) throws Exception {
         LoginToken loginToken = loginTokenRepository.findByToken(securityToken);
-        return userRepository.findOne(loginToken.getUserGuid().toString());
+        return userRepository.findOne(loginToken.getUserGuid());
     }
 }

--- a/src/main/java/org/dsmhack/controller/ProjectController.java
+++ b/src/main/java/org/dsmhack/controller/ProjectController.java
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 @CrossOrigin(origins = "http://localhost:4200")
 @RestController
@@ -41,9 +40,9 @@ public class ProjectController {
         return projectRepository.findAll();
     }
 
-    @GetMapping("/projects/{projectGuid}")
-    public Project getProjectById(@PathVariable String projectGuid) {
-        return projectRepository.findOne(projectGuid);
+    @GetMapping("/projects/{projectId}")
+    public Project getProjectById(@PathVariable String projectId) {
+        return projectRepository.findOne(projectId);
     }
 
     @PostMapping("/projects")
@@ -52,34 +51,34 @@ public class ProjectController {
         return new ResponseEntity<>(projectRepository.save(project), HttpStatus.CREATED);
     }
 
-    @GetMapping("/projects/{projectGuid}/check-ins")
-    public List<CheckIn> findAllCheckins(@PathVariable String projectGuid) {
-        return checkInRepository.findByProjGuid(projectGuid);
+    @GetMapping("/projects/{projectId}/check-ins")
+    public List<CheckIn> findAllCheckins(@PathVariable String projectId) {
+        return checkInRepository.findByProjGuid(projectId);
     }
 
-    @PostMapping("/projects/{projectGuid}/check-ins")
-    public ResponseEntity<CheckIn> checkUserIn(@PathVariable UUID projectGuid, @RequestBody UUID userGuid){
+    @PostMapping("/projects/{projectId}/check-ins")
+    public ResponseEntity<CheckIn> checkUserIn(@PathVariable String projectId, @RequestBody String userGuid){
         CheckIn checkIn = new CheckIn();
         checkIn.setUserGuid(userGuid);
-        checkIn.setProjGuid(projectGuid);
+        checkIn.setProjGuid(projectId);
         checkIn.setTimeIn(Timestamp.valueOf(LocalDateTime.now()));
         return new ResponseEntity<>(checkInRepository.save(checkIn), HttpStatus.CREATED);
     }
 
-    @PostMapping("/projects/{projectGuid}/user")
-    public UserProject addUser(@PathVariable UUID projectGuid, @RequestBody UUID userGuid){
+    @PostMapping("/projects/{projectId}/user")
+    public UserProject addUser(@PathVariable String projectId, @RequestBody String userGuid){
         UserProject userProject = new UserProject();
         UserProject.MyKey myKey = new UserProject.MyKey();
-        myKey.setProjGuid(projectGuid);
+        myKey.setProjGuid(projectId);
         myKey.setUserGuid(userGuid);
 
         userProject.setMyKey(myKey);
         return userProjectRepository.save(userProject);
     }
 
-    @PutMapping("/projects/{projectGuid}/check-ins")
-    public CheckIn checkOutUser(@PathVariable String projectGuid, @RequestBody String userGuid){
-        CheckIn checkIn = checkInRepository.findByProjGuidAndUserGuid(projectGuid, userGuid);
+    @PutMapping("/projects/{projectId}/check-ins")
+    public CheckIn checkOutUser(@PathVariable String projectId, @RequestBody String userGuid){
+        CheckIn checkIn = checkInRepository.findByProjGuidAndUserGuid(projectId, userGuid);
         checkIn.setTimeOut(Timestamp.valueOf(LocalDateTime.now()));
         return checkInRepository.save(checkIn);
     }

--- a/src/main/java/org/dsmhack/controller/UserController.java
+++ b/src/main/java/org/dsmhack/controller/UserController.java
@@ -58,7 +58,7 @@ public class UserController {
         List<UserProject> userProjectList = userProjectRepository.findAll();
         userProjectList.forEach(userProject -> {
             if(userProject.getMyKey().getUserGuid().equals(userGuid)){
-                Project project = projectRepository.findOne(userProject.getMyKey().getProjGuid().toString());
+                Project project = projectRepository.findOne(userProject.getMyKey().getProjGuid());
                 user.getProjectList().add(project);
             }
         });

--- a/src/main/java/org/dsmhack/model/CheckIn.java
+++ b/src/main/java/org/dsmhack/model/CheckIn.java
@@ -17,7 +17,6 @@ import com.google.gson.Gson;
 
 import javax.persistence.*;
 import java.sql.Timestamp;
-import java.util.UUID;
 
 @Entity
 @Table
@@ -25,10 +24,10 @@ public class CheckIn {
 
     @Id
     @Column
-    private UUID userGuid;
+    private String userGuid;
 
     @Column
-    private UUID projGuid;
+    private String projGuid;
 
     @Column
     private Timestamp timeIn;
@@ -38,20 +37,20 @@ public class CheckIn {
 
     public CheckIn(){}
 
-    public UUID getUserGuid() {
+    public String getUserGuid() {
         return userGuid;
     }
 
-    public CheckIn setUserGuid(UUID userGuid) {
+    public CheckIn setUserGuid(String userGuid) {
         this.userGuid = userGuid;
         return this;
     }
 
-    public UUID getProjGuid() {
+    public String getProjGuid() {
         return projGuid;
     }
 
-    public CheckIn setProjGuid(UUID projGuid) {
+    public CheckIn setProjGuid(String projGuid) {
         this.projGuid = projGuid;
         return this;
     }

--- a/src/main/java/org/dsmhack/model/LoginToken.java
+++ b/src/main/java/org/dsmhack/model/LoginToken.java
@@ -20,7 +20,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.sql.Timestamp;
-import java.util.UUID;
 
 @Entity
 @Table
@@ -28,7 +27,7 @@ public class LoginToken {
 
     @Id
     @Column
-    private UUID userGuid;
+    private String userGuid;
 
     @Column
     private String token;
@@ -36,11 +35,11 @@ public class LoginToken {
     @Column
     private Timestamp tokenExpDate;
 
-    public UUID getUserGuid() {
+    public String getUserGuid() {
         return userGuid;
     }
 
-    public LoginToken setUserGuid(UUID userGuid) {
+    public LoginToken setUserGuid(String userGuid) {
         this.userGuid = userGuid;
         return this;
     }

--- a/src/main/java/org/dsmhack/model/Organization.java
+++ b/src/main/java/org/dsmhack/model/Organization.java
@@ -19,14 +19,13 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import java.util.UUID;
 
 @Entity
 @Table
 public class Organization {
     @Id
     @Column
-    private UUID orgGuid;
+    private String orgGuid;
 
     @Column
     private String name;
@@ -64,11 +63,11 @@ public class Organization {
     @Column
     private String zip;
 
-    public UUID getOrgGuid() {
+    public String getOrgGuid() {
         return orgGuid;
     }
 
-    public Organization setOrgGuid(UUID orgGuid) {
+    public Organization setOrgGuid(String orgGuid) {
         this.orgGuid = orgGuid;
         return this;
     }

--- a/src/main/java/org/dsmhack/model/Project.java
+++ b/src/main/java/org/dsmhack/model/Project.java
@@ -35,7 +35,7 @@ import java.util.UUID;
 public class Project {
     @Id
     @Column
-    private UUID projGuid;
+    private String projGuid;
 
     @NotNull
     @Size(min = 1, max = 36)
@@ -61,11 +61,11 @@ public class Project {
     public Project() {
     }
 
-    public UUID getProjGuid() {
+    public String getProjGuid() {
         return projGuid;
     }
 
-    public Project setProjGuid(UUID projGuid) {
+    public Project setProjGuid(String projGuid) {
         this.projGuid = projGuid;
         return this;
     }

--- a/src/main/java/org/dsmhack/model/ReportData.java
+++ b/src/main/java/org/dsmhack/model/ReportData.java
@@ -3,12 +3,11 @@ package org.dsmhack.model;
 import com.google.gson.Gson;
 
 import java.sql.Timestamp;
-import java.util.UUID;
 
 public class ReportData {
-    private UUID projectGuid;
+    private String projectGuid;
     private String projectName;
-    private UUID userGuid;
+    private String userGuid;
     private String firstName;
     private String lastName;
     private Timestamp timeIn;
@@ -17,11 +16,11 @@ public class ReportData {
     public ReportData() {
     }
 
-    public UUID getProjectGuid() {
+    public String getProjectGuid() {
         return projectGuid;
     }
 
-    public ReportData setProjectGuid(UUID projectGuid) {
+    public ReportData setProjectGuid(String projectGuid) {
         this.projectGuid = projectGuid;
         return this;
     }
@@ -35,11 +34,11 @@ public class ReportData {
         return this;
     }
 
-    public UUID getUserGuid() {
+    public String getUserGuid() {
         return userGuid;
     }
 
-    public ReportData setUserGuid(UUID userGuid) {
+    public ReportData setUserGuid(String userGuid) {
         this.userGuid = userGuid;
         return this;
     }

--- a/src/main/java/org/dsmhack/model/ReportProject.java
+++ b/src/main/java/org/dsmhack/model/ReportProject.java
@@ -2,21 +2,19 @@ package org.dsmhack.model;
 
 import com.google.gson.Gson;
 
-import java.util.UUID;
-
 public class ReportProject   {
-  private UUID projectGuid;
+  private String projectGuid;
   private String name;
   private double totalHours = 0;
 
   public ReportProject() {
   }
 
-  public UUID getProjectGuid() {
+  public String getProjectGuid() {
     return projectGuid;
   }
 
-  public ReportProject setProjectGuid(UUID projectGuid) {
+  public ReportProject setProjectGuid(String projectGuid) {
     this.projectGuid = projectGuid;
     return this;
   }

--- a/src/main/java/org/dsmhack/model/ReportUser.java
+++ b/src/main/java/org/dsmhack/model/ReportUser.java
@@ -4,10 +4,9 @@ import com.google.gson.Gson;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 public class ReportUser {
-  private UUID userGuid;
+  private String userGuid;
   private String firstName;
   private String lastName;
   private List<ReportProject> projects = new ArrayList<ReportProject>();
@@ -16,11 +15,11 @@ public class ReportUser {
   public ReportUser() {
   }
 
-  public UUID getUserGuid() {
+  public String getUserGuid() {
     return userGuid;
   }
 
-  public ReportUser setUserGuid(UUID userGuid) {
+  public ReportUser setUserGuid(String userGuid) {
     this.userGuid = userGuid;
     return this;
   }

--- a/src/main/java/org/dsmhack/model/User.java
+++ b/src/main/java/org/dsmhack/model/User.java
@@ -21,14 +21,14 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Entity
 @Table
 public class User {
     @Id
     @Column
-    private UUID userGuid;
+    //todo: eventually move move to UUID
+    private String userGuid;
 
     @NotNull
     @Size(min = 1, max = 50)
@@ -57,11 +57,11 @@ public class User {
     public User() {
     }
 
-    public UUID getUserGuid() {
+    public String getUserGuid() {
         return userGuid;
     }
 
-    public User setUserGuid(UUID userGuid) {
+    public User setUserGuid(String userGuid) {
         this.userGuid = userGuid;
         return this;
     }

--- a/src/main/java/org/dsmhack/model/UserOrganization.java
+++ b/src/main/java/org/dsmhack/model/UserOrganization.java
@@ -39,24 +39,24 @@ public class UserOrganization {
     @Embeddable
     public class MyKey implements Serializable {
         @Column
-        private UUID userGuid;
+        private String userGuid;
 
         @Column
-        private UUID orgGuid;
+        private String orgGuid;
 
-        public UUID getUserGuid() {
+        public String getUserGuid() {
             return userGuid;
         }
 
-        public void setUserGuid(UUID userGuid) {
+        public void setUserGuid(String userGuid) {
             this.userGuid = userGuid;
         }
 
-        public UUID getOrgGuid() {
+        public String getOrgGuid() {
             return orgGuid;
         }
 
-        public void setOrgGuid(UUID orgGuid) {
+        public void setOrgGuid(String orgGuid) {
             this.orgGuid = orgGuid;
         }
     }

--- a/src/main/java/org/dsmhack/model/UserProject.java
+++ b/src/main/java/org/dsmhack/model/UserProject.java
@@ -38,24 +38,24 @@ public class UserProject {
     @Embeddable
     public static class MyKey implements Serializable {
         @Column
-        private UUID userGuid;
+        private String userGuid;
 
         @Column
-        private UUID projGuid;
+        private String projGuid;
 
-        public UUID getUserGuid() {
+        public String getUserGuid() {
             return userGuid;
         }
 
-        public void setUserGuid(UUID userGuid) {
+        public void setUserGuid(String userGuid) {
             this.userGuid = userGuid;
         }
 
-        public UUID getProjGuid() {
+        public String getProjGuid() {
             return projGuid;
         }
 
-        public void setProjGuid(UUID projGuid) {
+        public void setProjGuid(String projGuid) {
             this.projGuid = projGuid;
         }
     }

--- a/src/main/java/org/dsmhack/service/CodeGenerator.java
+++ b/src/main/java/org/dsmhack/service/CodeGenerator.java
@@ -8,8 +8,8 @@ import java.util.UUID;
 @Service
 public class CodeGenerator {
 
-    public UUID generateUUID(){
-        return UUID.randomUUID();
+    public String generateUUID(){
+        return UUID.randomUUID().toString();
     }
 
     public String generateLoginToken(){

--- a/src/main/java/org/dsmhack/service/ReportService.java
+++ b/src/main/java/org/dsmhack/service/ReportService.java
@@ -12,7 +12,6 @@ import java.sql.Timestamp;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 public class ReportService {
@@ -103,7 +102,7 @@ public class ReportService {
         return uniqueUsers;
     }
 
-    ReportUser findUser(UUID guid, List<ReportUser> users) {
+    ReportUser findUser(String guid, List<ReportUser> users) {
         for (ReportUser user : users) {
             if (user.getUserGuid().equals(guid)) {
                 return user;
@@ -112,7 +111,7 @@ public class ReportService {
         return new ReportUser();
     }
 
-    boolean projectGuidExists(UUID guid, List<ReportProject> projects) {
+    boolean projectGuidExists(String guid, List<ReportProject> projects) {
         for (ReportProject project : projects) {
             if (project.getProjectGuid().equals(guid)) {
                 return true;
@@ -121,7 +120,7 @@ public class ReportService {
         return false;
     }
 
-    ReportProject findReportProject(UUID guid, List<ReportProject> projects) {
+    ReportProject findReportProject(String guid, List<ReportProject> projects) {
         for (ReportProject project: projects) {
             if (project.getProjectGuid().equals(guid)) {
                 return project;
@@ -130,7 +129,7 @@ public class ReportService {
         return new ReportProject();
     }
 
-    boolean userGuidExists(UUID guid, List<ReportUser> users) {
+    boolean userGuidExists(String guid, List<ReportUser> users) {
         for (ReportUser user : users) {
             if (user.getUserGuid().equals(guid)) {
                 return true;

--- a/src/test/java/org/dsmhack/controller/ProjectControllerTest.java
+++ b/src/test/java/org/dsmhack/controller/ProjectControllerTest.java
@@ -23,7 +23,6 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.UUID;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
@@ -75,7 +74,7 @@ public class ProjectControllerTest {
 
     @Test
     public void postCallsGuidGeneratorToGenerateUUIDBeforeSavingProject() throws Exception {
-        UUID projectId = UUID.randomUUID();
+        String projectId = "randomUUID";
         when(codeGenerator.generateUUID()).thenReturn(projectId);
         projectController.save(new Project());
         ArgumentCaptor<Project> captor = ArgumentCaptor.forClass(Project.class);
@@ -173,30 +172,26 @@ public class ProjectControllerTest {
 
     @Test
     public void checkinReturns201() throws Exception {
-        String projectGuid = UUID.randomUUID().toString();
-        MvcResult mvcResult = mockMvc.perform(post("/projects/" + projectGuid + "/check-ins")
+        mockMvc.perform(post("/projects/12345/check-ins")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(UUID.randomUUID().toString()))
-                /*.andExpect(status().isCreated())*/.andReturn();
-        System.out.printf("blip");
+                .content("user-uuid"))
+                .andExpect(status().isCreated());
     }
 
     @Test
     public void postToCheckinCallsRepositoryWithCheckIn() throws Exception {
-        UUID projectGuid = UUID.randomUUID();
-        UUID userGuid = UUID.randomUUID();
-        projectController.checkUserIn(projectGuid, userGuid);
+        projectController.checkUserIn("12345", "userId");
         ArgumentCaptor<CheckIn> captor = ArgumentCaptor.forClass(CheckIn.class);
         verify(checkInRepository).save(captor.capture());
-        assertEquals(userGuid, captor.getValue().getUserGuid());
-        assertEquals(projectGuid, captor.getValue().getProjGuid());
+        assertEquals("userId", captor.getValue().getUserGuid());
+        assertEquals("12345", captor.getValue().getProjGuid());
     }
 
     @Test
     public void checkInReturnsCheckIn() throws Exception {
         CheckIn expectedCheckin = new CheckIn();
         when(checkInRepository.save(any(CheckIn.class))).thenReturn(expectedCheckin);
-        assertEquals(expectedCheckin, projectController.checkUserIn(UUID.randomUUID(), UUID.randomUUID()).getBody());
+        assertEquals(expectedCheckin, projectController.checkUserIn("12345", "userId").getBody());
     }
 
     @Test

--- a/src/test/java/org/dsmhack/controller/UserControllerTest.java
+++ b/src/test/java/org/dsmhack/controller/UserControllerTest.java
@@ -17,7 +17,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -139,7 +138,7 @@ public class UserControllerTest {
 
     @Test
     public void postCallsGuidGeneratorToGenerateUUIDBeforeSavingUser() throws Exception {
-        UUID userId = UUID.randomUUID();
+        String userId = "uuid";
         when(codeGenerator.generateUUID()).thenReturn(userId);
         userController.save(new User());
         ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);

--- a/src/test/java/org/dsmhack/service/CodeGeneratorTest.java
+++ b/src/test/java/org/dsmhack/service/CodeGeneratorTest.java
@@ -2,8 +2,6 @@ package org.dsmhack.service;
 
 import org.junit.Test;
 
-import java.util.UUID;
-
 import static org.junit.Assert.*;
 
 public class CodeGeneratorTest {
@@ -11,8 +9,8 @@ public class CodeGeneratorTest {
     @Test
     public void generateGuidReturnsUniqueUUID() throws Exception {
         CodeGenerator codeGenerator = new CodeGenerator();
-        UUID firstUUID = codeGenerator.generateUUID();
-        UUID secondUUID = codeGenerator.generateUUID();
+        String firstUUID = codeGenerator.generateUUID();
+        String secondUUID = codeGenerator.generateUUID();
         assertNotEquals(firstUUID, secondUUID);
     }
 

--- a/src/test/java/org/dsmhack/service/LoginServiceTest.java
+++ b/src/test/java/org/dsmhack/service/LoginServiceTest.java
@@ -11,8 +11,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.UUID;
-
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
@@ -58,12 +56,11 @@ public class LoginServiceTest {
     public void loginSavesTokenToRepositoryWithCorrectFields() throws Exception {
         when(codeGenerator.generateLoginToken()).thenReturn("123");
         User user = new User();
-        UUID userGuid = UUID.randomUUID();
-        user.setUserGuid(userGuid);
+        user.setUserGuid("userGuid");
         loginService.login(user);
         ArgumentCaptor<LoginToken> captor = ArgumentCaptor.forClass(LoginToken.class);
         verify(loginTokenRepository).save(captor.capture());
         assertEquals("123", captor.getValue().getToken());
-        assertEquals(userGuid, captor.getValue().getUserGuid());
+        assertEquals("userGuid", captor.getValue().getUserGuid());
     }
 }

--- a/src/test/java/org/dsmhack/service/ReportServiceTest.java
+++ b/src/test/java/org/dsmhack/service/ReportServiceTest.java
@@ -15,7 +15,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
@@ -33,10 +32,9 @@ public class ReportServiceTest {
     public void callsReportRepoAndMapsToApiObject_happyPath() throws Exception {
         String organizationId = "12341235135";
         ReportData reportData = new ReportData();
-        reportData.setProjectGuid(UUID.randomUUID());
+        reportData.setProjectGuid("projectGuid1");
         reportData.setProjectName("Project #1");
-        UUID userGuid = UUID.randomUUID();
-        reportData.setUserGuid(userGuid);
+        reportData.setUserGuid("someGuid");
         reportData.setFirstName("John");
         reportData.setLastName("Doe");
         reportData.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
@@ -51,7 +49,7 @@ public class ReportServiceTest {
         assertEquals(8, organizationProject.getTotalHours(), 0.0001);
 
         ReportUser reportUser = reportOrganization.getUsers().get(0);
-        assertEquals(userGuid, reportUser.getUserGuid());
+        assertEquals("someGuid", reportUser.getUserGuid());
         assertEquals("John", reportUser.getFirstName());
         assertEquals("Doe", reportUser.getLastName());
         ReportProject userProject = reportUser.getProjects().get(0);
@@ -66,27 +64,25 @@ public class ReportServiceTest {
     public void callsReportRepoAndMapsToApiObject_fractionsOfAnHourShouldStillAddUpToAnHour() throws Exception {
         String organizationId = "12341235135";
         ReportData reportData1 = new ReportData();
-        UUID projectGuid1 = UUID.randomUUID();
-        reportData1.setProjectGuid(projectGuid1);
+        reportData1.setProjectGuid("projectGuid1");
         reportData1.setProjectName("Project #1");
-        UUID someGuid = UUID.randomUUID();
-        reportData1.setUserGuid(someGuid);
+        reportData1.setUserGuid("someGuid");
         reportData1.setFirstName("John");
         reportData1.setLastName("Doe");
         reportData1.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
         reportData1.setTimeOut(Timestamp.valueOf("2018-01-01 09:20:00"));
         ReportData reportData2 = new ReportData();
-        reportData2.setProjectGuid(projectGuid1);
+        reportData2.setProjectGuid("projectGuid1");
         reportData2.setProjectName("Project #1");
-        reportData2.setUserGuid(someGuid);
+        reportData2.setUserGuid("someGuid");
         reportData2.setFirstName("John");
         reportData2.setLastName("Doe");
         reportData2.setTimeIn(Timestamp.valueOf("2018-01-01 10:00:00"));
         reportData2.setTimeOut(Timestamp.valueOf("2018-01-01 10:20:00"));
         ReportData reportData3 = new ReportData();
-        reportData3.setProjectGuid(projectGuid1);
+        reportData3.setProjectGuid("projectGuid1");
         reportData3.setProjectName("Project #1");
-        reportData3.setUserGuid(someGuid);
+        reportData3.setUserGuid("someGuid");
         reportData3.setFirstName("John");
         reportData3.setLastName("Doe");
         reportData3.setTimeIn(Timestamp.valueOf("2018-01-01 11:00:00"));
@@ -101,7 +97,7 @@ public class ReportServiceTest {
         assertEquals(1, organizationProject.getTotalHours(), 0.0001);
 
         ReportUser reportUser = reportOrganization.getUsers().get(0);
-        assertEquals(someGuid, reportUser.getUserGuid());
+        assertEquals("someGuid", reportUser.getUserGuid());
         assertEquals("John", reportUser.getFirstName());
         assertEquals("Doe", reportUser.getLastName());
         ReportProject userProject = reportUser.getProjects().get(0);
@@ -116,20 +112,17 @@ public class ReportServiceTest {
     public void callsReportRepoAndMapsToApiObject_multipleUsersOneProject() throws Exception {
         String organizationId = "12341235135";
         ReportData reportData1 = new ReportData();
-        UUID projectGuid1 = UUID.randomUUID();
-        reportData1.setProjectGuid(projectGuid1);
+        reportData1.setProjectGuid("projectGuid1");
         reportData1.setProjectName("Project #1");
-        UUID someGuid1 = UUID.randomUUID();
-        reportData1.setUserGuid(someGuid1);
+        reportData1.setUserGuid("someGuid1");
         reportData1.setFirstName("John");
         reportData1.setLastName("Doe");
         reportData1.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
         reportData1.setTimeOut(Timestamp.valueOf("2018-01-01 17:00:00"));
         ReportData reportData2 = new ReportData();
-        reportData2.setProjectGuid(projectGuid1);
+        reportData2.setProjectGuid("projectGuid1");
         reportData2.setProjectName("Project #1");
-        UUID someGuid2 = UUID.randomUUID();
-        reportData2.setUserGuid(someGuid2);
+        reportData2.setUserGuid("someGuid2");
         reportData2.setFirstName("Tim");
         reportData2.setLastName("Smith");
         reportData2.setTimeIn(Timestamp.valueOf("2018-02-02 09:00:00"));
@@ -145,7 +138,7 @@ public class ReportServiceTest {
         assertEquals(14, organizationProject.getTotalHours(), 0.0001);
 
         ReportUser reportUser1 = reportOrganization.getUsers().get(0);
-        assertEquals(someGuid1, reportUser1.getUserGuid());
+        assertEquals("someGuid1", reportUser1.getUserGuid());
         assertEquals("John", reportUser1.getFirstName());
         assertEquals("Doe", reportUser1.getLastName());
         ReportProject userProject1 = reportUser1.getProjects().get(0);
@@ -153,7 +146,7 @@ public class ReportServiceTest {
         assertEquals(8, userProject1.getTotalHours(), 0.0001);
         assertEquals(8, reportUser1.getTotalHours(), 0.0001);
         ReportUser reportUser2 = reportOrganization.getUsers().get(1);
-        assertEquals(someGuid2, reportUser2.getUserGuid());
+        assertEquals("someGuid2", reportUser2.getUserGuid());
         assertEquals("Tim", reportUser2.getFirstName());
         assertEquals("Smith", reportUser2.getLastName());
         ReportProject userProject2 = reportUser2.getProjects().get(0);
@@ -168,20 +161,17 @@ public class ReportServiceTest {
     public void callsReportRepoAndMapsToApiObject_multipleProjectsOneUser() throws Exception {
         String organizationId = "12341235135";
         ReportData reportData1 = new ReportData();
-        UUID projectGuid1 = UUID.randomUUID();
-        reportData1.setProjectGuid(projectGuid1);
+        reportData1.setProjectGuid("projectGuid1");
         reportData1.setProjectName("Project #1");
-        UUID userGuid = UUID.randomUUID();
-        reportData1.setUserGuid(userGuid);
+        reportData1.setUserGuid("userGuid");
         reportData1.setFirstName("John");
         reportData1.setLastName("Doe");
         reportData1.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
         reportData1.setTimeOut(Timestamp.valueOf("2018-01-01 17:00:00"));
         ReportData reportData2 = new ReportData();
-        UUID projectGuid2 = UUID.randomUUID();
-        reportData2.setProjectGuid(projectGuid2);
+        reportData2.setProjectGuid("projectGuid2");
         reportData2.setProjectName("Project #2");
-        reportData2.setUserGuid(userGuid);
+        reportData2.setUserGuid("userGuid");
         reportData2.setFirstName("John");
         reportData2.setLastName("Doe");
         reportData2.setTimeIn(Timestamp.valueOf("2018-01-02 09:00:00"));
@@ -201,15 +191,15 @@ public class ReportServiceTest {
 
         assertEquals(1, reportOrganization.getUsers().size());
         ReportUser reportUser = reportOrganization.getUsers().get(0);
-        assertEquals(userGuid, reportUser.getUserGuid());
+        assertEquals("userGuid", reportUser.getUserGuid());
         assertEquals("John", reportUser.getFirstName());
         assertEquals("Doe", reportUser.getLastName());
         ReportProject userProject1 = reportUser.getProjects().get(0);
-        assertEquals(projectGuid1, userProject1.getProjectGuid());
+        assertEquals("projectGuid1", userProject1.getProjectGuid());
         assertEquals("Project #1", userProject1.getName());
         assertEquals(8, userProject1.getTotalHours(), 0.0001);
         ReportProject userProject2 = reportUser.getProjects().get(1);
-        assertEquals(projectGuid2, userProject2.getProjectGuid());
+        assertEquals("projectGuid2", userProject2.getProjectGuid());
         assertEquals("Project #2", userProject2.getName());
         assertEquals(6, userProject2.getTotalHours(), 0.0001);
         assertEquals(14, reportUser.getTotalHours(), 0.0001);
@@ -221,19 +211,17 @@ public class ReportServiceTest {
     public void callsReportRepoAndMapsToApiObject_oneUserOneProjectMultipleDays() throws Exception {
         String organizationId = "12341235135";
         ReportData reportData1 = new ReportData();
-        UUID projectGuid = UUID.randomUUID();
-        reportData1.setProjectGuid(projectGuid);
+        reportData1.setProjectGuid("projectGuid");
         reportData1.setProjectName("Project #1");
-        UUID userGuid = UUID.randomUUID();
-        reportData1.setUserGuid(userGuid);
+        reportData1.setUserGuid("userGuid");
         reportData1.setFirstName("John");
         reportData1.setLastName("Doe");
         reportData1.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
         reportData1.setTimeOut(Timestamp.valueOf("2018-01-01 17:00:00"));
         ReportData reportData2 = new ReportData();
-        reportData2.setProjectGuid(projectGuid);
+        reportData2.setProjectGuid("projectGuid");
         reportData2.setProjectName("Project #1");
-        reportData2.setUserGuid(userGuid);
+        reportData2.setUserGuid("userGuid");
         reportData2.setFirstName("John");
         reportData2.setLastName("Smith");
         reportData2.setTimeIn(Timestamp.valueOf("2018-02-02 09:00:00"));
@@ -251,11 +239,11 @@ public class ReportServiceTest {
         assertEquals(1, reportOrganization.getUsers().size());
         assertEquals(1, reportOrganization.getUsers().get(0).getProjects().size());
         ReportUser reportUser1 = reportOrganization.getUsers().get(0);
-        assertEquals(userGuid, reportUser1.getUserGuid());
+        assertEquals("userGuid", reportUser1.getUserGuid());
         assertEquals("John", reportUser1.getFirstName());
         assertEquals("Doe", reportUser1.getLastName());
         ReportProject userProject1 = reportUser1.getProjects().get(0);
-        assertEquals(projectGuid, userProject1.getProjectGuid());
+        assertEquals("projectGuid", userProject1.getProjectGuid());
         assertEquals("Project #1", userProject1.getName());
         assertEquals(14, userProject1.getTotalHours(), 0.0001);
         assertEquals(14, reportUser1.getTotalHours(), 0.0001);
@@ -267,29 +255,25 @@ public class ReportServiceTest {
     public void callsReportRepoAndMapsToApiObject_twoUsersHaveHoursForOneProjectButOnlyOneUserHasHoursForAnotherProject() throws Exception {
         String organizationId = "12341235135";
         ReportData reportData1 = new ReportData();
-        UUID projectGuid1 = UUID.randomUUID();
-        reportData1.setProjectGuid(projectGuid1);
+        reportData1.setProjectGuid("projectGuid1");
         reportData1.setProjectName("Project #1");
-        UUID someGuid1 = UUID.randomUUID();
-        reportData1.setUserGuid(someGuid1);
+        reportData1.setUserGuid("someGuid1");
         reportData1.setFirstName("John");
         reportData1.setLastName("Doe");
         reportData1.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
         reportData1.setTimeOut(Timestamp.valueOf("2018-01-01 17:00:00"));
         ReportData reportData2 = new ReportData();
-        reportData2.setProjectGuid(projectGuid1);
+        reportData2.setProjectGuid("projectGuid1");
         reportData2.setProjectName("Project #1");
-        UUID someGuid2 = UUID.randomUUID();
-        reportData2.setUserGuid(someGuid2);
+        reportData2.setUserGuid("someGuid2");
         reportData2.setFirstName("Tim");
         reportData2.setLastName("Smith");
         reportData2.setTimeIn(Timestamp.valueOf("2018-02-02 09:00:00"));
         reportData2.setTimeOut(Timestamp.valueOf("2018-02-02 15:00:00"));
         ReportData reportData3 = new ReportData();
-        UUID projectGuid2 = UUID.randomUUID();
-        reportData3.setProjectGuid(projectGuid2);
+        reportData3.setProjectGuid("projectGuid2");
         reportData3.setProjectName("Project #2");
-        reportData3.setUserGuid(someGuid1);
+        reportData3.setUserGuid("someGuid1");
         reportData3.setFirstName("John");
         reportData3.setLastName("Doe");
         reportData3.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
@@ -308,7 +292,7 @@ public class ReportServiceTest {
         assertEquals(8, organizationProject2.getTotalHours(), 0.0001);
 
         ReportUser reportUser1 = reportOrganization.getUsers().get(0);
-        assertEquals(someGuid1, reportUser1.getUserGuid());
+        assertEquals("someGuid1", reportUser1.getUserGuid());
         assertEquals("John", reportUser1.getFirstName());
         assertEquals("Doe", reportUser1.getLastName());
         ReportProject userProject1 = reportUser1.getProjects().get(0);
@@ -319,7 +303,7 @@ public class ReportServiceTest {
         assertEquals(8, userProject2.getTotalHours(), 0.0001);
         assertEquals(16, reportUser1.getTotalHours(), 0.0001);
         ReportUser reportUser2 = reportOrganization.getUsers().get(1);
-        assertEquals(someGuid2, reportUser2.getUserGuid());
+        assertEquals("someGuid2", reportUser2.getUserGuid());
         assertEquals("Tim", reportUser2.getFirstName());
         assertEquals("Smith", reportUser2.getLastName());
         ReportProject userProject3 = reportUser2.getProjects().get(0);
@@ -337,25 +321,21 @@ public class ReportServiceTest {
     public void buildsBaseStructureBasedOffUniqueProjectsAndUsers() throws Exception {
         String organizationId = "12341235135";
         ReportData reportData1 = new ReportData();
-        UUID projectGuid1 = UUID.randomUUID();
-        reportData1.setProjectGuid(projectGuid1);
+        reportData1.setProjectGuid("projectGuid1");
         reportData1.setProjectName("Project #1");
-        UUID someGuid1 = UUID.randomUUID();
-        reportData1.setUserGuid(someGuid1);
+        reportData1.setUserGuid("someGuid1");
         reportData1.setFirstName("John");
         reportData1.setLastName("Doe");
         ReportData reportData2 = new ReportData();
-        reportData2.setProjectGuid(projectGuid1);
+        reportData2.setProjectGuid("projectGuid1");
         reportData2.setProjectName("Project #1");
-        UUID someGuid2 = UUID.randomUUID();
-        reportData2.setUserGuid(someGuid2);
+        reportData2.setUserGuid("someGuid2");
         reportData2.setFirstName("Tim");
         reportData2.setLastName("Smith");
         ReportData reportData3 = new ReportData();
-        UUID projectGuid2 = UUID.randomUUID();
-        reportData3.setProjectGuid(projectGuid2);
+        reportData3.setProjectGuid("projectGuid2");
         reportData3.setProjectName("Project #2");
-        reportData3.setUserGuid(someGuid1);
+        reportData3.setUserGuid("someGuid1");
         reportData3.setFirstName("John");
         reportData3.setLastName("Doe");
         List<ReportData> reportDatas = Arrays.asList(reportData1, reportData2, reportData3);
@@ -371,7 +351,7 @@ public class ReportServiceTest {
         assertEquals(0, organizationProject2.getTotalHours(), 0.0001);
 
         ReportUser reportUser1 = reportOrganization.getUsers().get(0);
-        assertEquals(someGuid1, reportUser1.getUserGuid());
+        assertEquals("someGuid1", reportUser1.getUserGuid());
         assertEquals("John", reportUser1.getFirstName());
         assertEquals("Doe", reportUser1.getLastName());
         ReportProject userProject1 = reportUser1.getProjects().get(0);
@@ -382,7 +362,7 @@ public class ReportServiceTest {
         assertEquals(0, userProject2.getTotalHours(), 0.0001);
         assertEquals(0, reportUser1.getTotalHours(), 0.0001);
         ReportUser reportUser2 = reportOrganization.getUsers().get(1);
-        assertEquals(someGuid2, reportUser2.getUserGuid());
+        assertEquals("someGuid2", reportUser2.getUserGuid());
         assertEquals("Tim", reportUser2.getFirstName());
         assertEquals("Smith", reportUser2.getLastName());
         ReportProject userProject3 = reportUser2.getProjects().get(0);
@@ -399,7 +379,7 @@ public class ReportServiceTest {
     @Test
     public void findTheProjectGivenTheGuid_exists() {
         ReportProject reportProject = new ReportProject();
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         reportProject.setProjectGuid(guid);
         List<ReportProject> reportProjects = Arrays.asList(reportProject);
 
@@ -410,7 +390,7 @@ public class ReportServiceTest {
 
     @Test
     public void findTheProjectGivenTheGuid_doesNotExists() {
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         List<ReportProject> reportProjects = Arrays.asList();
 
         ReportProject project = reportService.findReportProject(guid, reportProjects);
@@ -421,7 +401,7 @@ public class ReportServiceTest {
     @Test
     public void checkIfGuidExistsInProjectList_true() {
         ReportProject reportProject = new ReportProject();
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         reportProject.setProjectGuid(guid);
         List<ReportProject> reportProjects = Arrays.asList(reportProject);
 
@@ -432,7 +412,7 @@ public class ReportServiceTest {
 
     @Test
     public void checkIfGuidExistsInProjectList_false() {
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         List<ReportProject> reportProjects = new ArrayList<ReportProject>();
 
         boolean guidExists = reportService.projectGuidExists(guid, reportProjects);
@@ -443,7 +423,7 @@ public class ReportServiceTest {
     @Test
     public void findTheUserGivenTheGuid_exists() {
         ReportUser reportUser = new ReportUser();
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         reportUser.setUserGuid(guid);
         List<ReportUser> users = Arrays.asList(reportUser);
 
@@ -454,7 +434,7 @@ public class ReportServiceTest {
 
     @Test
     public void findTheUserGivenTheGuid_doesNotExists() {
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         List<ReportUser> users = Arrays.asList();
 
         ReportUser user = reportService.findUser(guid, users);
@@ -465,7 +445,7 @@ public class ReportServiceTest {
     @Test
     public void checkIfGuidExistsInUserList_true() {
         ReportUser reportUser = new ReportUser();
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         reportUser.setUserGuid(guid);
         List<ReportUser> users = Arrays.asList(reportUser);
 
@@ -476,7 +456,7 @@ public class ReportServiceTest {
 
     @Test
     public void checkIfGuidExistsInUserList_false() {
-        UUID guid = UUID.randomUUID();
+        String guid = "someGuid";
         List<ReportUser> users = new ArrayList<ReportUser>();
 
         boolean guidExists = reportService.userGuidExists(guid, users);
@@ -494,6 +474,7 @@ public class ReportServiceTest {
         assertEquals(7.5, diffInHours, 0.0001);
     }
 
+    //todo: If checkOut is null, we cannot calculate hours, so return 0. We could potientially assume they're in the middle of volunteering and use now as the end. Need to ask the business.
     @Test
     public void hoursBasedOnCheckInCheckOut_checkOutNull() throws Exception {
         Timestamp checkIn = Timestamp.valueOf("2018-01-01 09:00:00");
@@ -508,13 +489,17 @@ public class ReportServiceTest {
     public void reportDataAsCsv() {
         String organizationId = "12341235135";
         ReportData reportData1 = new ReportData();
+        reportData1.setProjectGuid("projectGuid1");
         reportData1.setProjectName("Project #1");
+        reportData1.setUserGuid("someGuid");
         reportData1.setFirstName("John");
         reportData1.setLastName("Doe");
         reportData1.setTimeIn(Timestamp.valueOf("2018-01-01 09:00:00"));
         reportData1.setTimeOut(Timestamp.valueOf("2018-01-01 17:00:00"));
         ReportData reportData2 = new ReportData();
+        reportData2.setProjectGuid("projectGuid2");
         reportData2.setProjectName("Project #2");
+        reportData2.setUserGuid("someGuid");
         reportData2.setFirstName("Jane");
         reportData2.setLastName("Smith");
         reportData2.setTimeIn(Timestamp.valueOf("2018-01-01 10:00:00"));


### PR DESCRIPTION
Things are currently broken because I switched to UUID datatype; the string solution does not have any issues. I may approach switching this again in the future. Something about JPA's `findOne` method had issues; I switched the underlying repo to use `UUID` rather than `String`, but it then had some other issues. Just reverting to get back to a working state.