### PR TITLE
Fix auth to use spring security

### DIFF
--- a/api.env.example
+++ b/api.env.example
@@ -1,2 +1,2 @@
 sendgridapikey=
-jwtSecret=
+jwtsecret=

--- a/src/main/java/org/dsmhack/config/AppUserDetailsService.java
+++ b/src/main/java/org/dsmhack/config/AppUserDetailsService.java
@@ -9,7 +9,6 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Collections;
 

--- a/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
+++ b/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
@@ -34,6 +34,7 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res) throws AuthenticationException {
+        //todo: this never gets triggered, which is a problem
         try {
             LoginToken credentials = new ObjectMapper().readValue(req.getInputStream(), LoginToken.class);
             return authenticationManager.authenticate(

--- a/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
+++ b/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.dsmhack.model.LoginToken;
+import org.dsmhack.repository.LoginTokenRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -27,6 +29,7 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     private final String jwtEncryptionKey;
     private final AuthenticationManager authenticationManager;
 
+
     public JWTAuthenticationFilter(AuthenticationManager authenticationManager, String jwtEncryptionKey) {
         this.authenticationManager = authenticationManager;
         this.jwtEncryptionKey = jwtEncryptionKey;
@@ -34,11 +37,10 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res) throws AuthenticationException {
-        //todo: this never gets triggered, which is a problem
         try {
             LoginToken credentials = new ObjectMapper().readValue(req.getInputStream(), LoginToken.class);
             return authenticationManager.authenticate(
-                    new UsernamePasswordAuthenticationToken(credentials.getUserGuid(), credentials.getToken(), new ArrayList<>())
+                new UsernamePasswordAuthenticationToken(credentials.getUserGuid(), credentials.getToken(), new ArrayList<>())
             );
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
+++ b/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
@@ -6,12 +6,14 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import org.dsmhack.model.LoginToken;
 import org.dsmhack.repository.LoginTokenRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -28,19 +30,21 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
 
     private final String jwtEncryptionKey;
     private final AuthenticationManager authenticationManager;
+    private final LoginTokenRepository loginTokenRepository;
 
-
-    public JWTAuthenticationFilter(AuthenticationManager authenticationManager, String jwtEncryptionKey) {
+    public JWTAuthenticationFilter(AuthenticationManager authenticationManager, String jwtEncryptionKey, ApplicationContext ctx) {
         this.authenticationManager = authenticationManager;
         this.jwtEncryptionKey = jwtEncryptionKey;
+        this.loginTokenRepository = ctx.getBean(LoginTokenRepository.class);
     }
 
     @Override
     public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res) throws AuthenticationException {
         try {
             LoginToken credentials = new ObjectMapper().readValue(req.getInputStream(), LoginToken.class);
+            LoginToken loginToken = this.loginTokenRepository.findByToken(credentials.getToken());
             return authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(credentials.getUserGuid(), credentials.getToken(), new ArrayList<>())
+                new UsernamePasswordAuthenticationToken(loginToken.getUserGuid(), loginToken.getToken(), new ArrayList<>())
             );
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
+++ b/src/main/java/org/dsmhack/config/JWTAuthenticationFilter.java
@@ -41,8 +41,8 @@ public class JWTAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     @Override
     public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res) throws AuthenticationException {
         try {
-            LoginToken credentials = new ObjectMapper().readValue(req.getInputStream(), LoginToken.class);
-            LoginToken loginToken = this.loginTokenRepository.findByToken(credentials.getToken());
+            String securityToken = req.getReader().lines().reduce("", (accumulator, actual) -> accumulator + actual);
+            LoginToken loginToken = this.loginTokenRepository.findByToken(securityToken);
             return authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(loginToken.getUserGuid(), loginToken.getToken(), new ArrayList<>())
             );

--- a/src/main/java/org/dsmhack/config/JWTAuthorizationFilter.java
+++ b/src/main/java/org/dsmhack/config/JWTAuthorizationFilter.java
@@ -28,17 +28,15 @@ public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
             throws IOException, ServletException {
-        String header = request.getHeader(HEADER_STRING);
+        final String header = request.getHeader(HEADER_STRING);
 
-        boolean doesNotHaveBearer = header == null || !header.startsWith(TOKEN_PREFIX);
-        if (doesNotHaveBearer) {
-            chain.doFilter(request, response);
-            return;
+        final boolean hasBearer = header != null && header.startsWith(TOKEN_PREFIX);
+        if (hasBearer) {
+            UsernamePasswordAuthenticationToken authentication = getAuthentication(request);
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
-        UsernamePasswordAuthenticationToken authentication = getAuthentication(request);
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
         chain.doFilter(request, response);
     }
 

--- a/src/main/java/org/dsmhack/config/JWTAuthorizationFilter.java
+++ b/src/main/java/org/dsmhack/config/JWTAuthorizationFilter.java
@@ -31,6 +31,7 @@ public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
         String header = request.getHeader(HEADER_STRING);
 
         if (header == null || !header.startsWith(TOKEN_PREFIX)) {
+            //todo: seems like the issue is here. This should call requiresAuthentication which should then call attemptAuthentication according to https://docs.spring.io/spring-security/site/docs/4.2.6.RELEASE/apidocs/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.html
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/org/dsmhack/config/JWTAuthorizationFilter.java
+++ b/src/main/java/org/dsmhack/config/JWTAuthorizationFilter.java
@@ -30,8 +30,8 @@ public class JWTAuthorizationFilter extends BasicAuthenticationFilter {
             throws IOException, ServletException {
         String header = request.getHeader(HEADER_STRING);
 
-        if (header == null || !header.startsWith(TOKEN_PREFIX)) {
-            //todo: seems like the issue is here. This should call requiresAuthentication which should then call attemptAuthentication according to https://docs.spring.io/spring-security/site/docs/4.2.6.RELEASE/apidocs/org/springframework/security/web/authentication/AbstractAuthenticationProcessingFilter.html
+        boolean doesNotHaveBearer = header == null || !header.startsWith(TOKEN_PREFIX);
+        if (doesNotHaveBearer) {
             chain.doFilter(request, response);
             return;
         }

--- a/src/main/java/org/dsmhack/config/SwaggerConfig.java
+++ b/src/main/java/org/dsmhack/config/SwaggerConfig.java
@@ -4,9 +4,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiKey;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.Collections;
 
 @Configuration
 @EnableSwagger2
@@ -17,6 +20,11 @@ public class SwaggerConfig {
                 .select()
                 .apis(RequestHandlerSelectors.basePackage("org.dsmhack"))
                 .paths(PathSelectors.any())
-                .build();
+                .build()
+                .securitySchemes(Collections.singletonList(apiKey()));
+    }
+
+    private ApiKey apiKey() {
+        return new ApiKey("apiKey", "Authorization", "header");
     }
 }

--- a/src/main/java/org/dsmhack/config/WebSecurity.java
+++ b/src/main/java/org/dsmhack/config/WebSecurity.java
@@ -35,7 +35,7 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET, "/webjars/springfox-swagger-ui/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
-                .addFilter(new JWTAuthenticationFilter(authenticationManager(), jwtEncryptionKey))
+                .addFilter(new JWTAuthenticationFilter(authenticationManager(), jwtEncryptionKey, getApplicationContext()))
                 .addFilter(new JWTAuthorizationFilter(authenticationManager(), jwtEncryptionKey))
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
     }

--- a/src/main/java/org/dsmhack/config/WebSecurity.java
+++ b/src/main/java/org/dsmhack/config/WebSecurity.java
@@ -28,7 +28,7 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.cors().and().csrf().disable().authorizeRequests()
-                .antMatchers(HttpMethod.POST, "/login/**").permitAll()
+                .antMatchers(HttpMethod.POST, "/login/sendCode").permitAll()
                 .antMatchers(HttpMethod.GET, "/swagger**").permitAll()
                 .antMatchers(HttpMethod.GET, "/swagger-resources/**").permitAll()
                 .antMatchers(HttpMethod.GET, "/v2/api-docs/**").permitAll()

--- a/src/main/java/org/dsmhack/config/WebSecurity.java
+++ b/src/main/java/org/dsmhack/config/WebSecurity.java
@@ -19,7 +19,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @EnableWebSecurity
 public class WebSecurity extends WebSecurityConfigurerAdapter {
 
-    @Value("${jwtSecret}")
+    @Value("${jwt.secret}")
     private String jwtEncryptionKey;
 
     @Autowired

--- a/src/main/java/org/dsmhack/config/WebSecurity.java
+++ b/src/main/java/org/dsmhack/config/WebSecurity.java
@@ -32,6 +32,7 @@ public class WebSecurity extends WebSecurityConfigurerAdapter {
                 .antMatchers(HttpMethod.GET, "/swagger**").permitAll()
                 .antMatchers(HttpMethod.GET, "/swagger-resources/**").permitAll()
                 .antMatchers(HttpMethod.GET, "/v2/api-docs/**").permitAll()
+                .antMatchers(HttpMethod.GET, "/webjars/springfox-swagger-ui/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilter(new JWTAuthenticationFilter(authenticationManager(), jwtEncryptionKey))

--- a/src/main/java/org/dsmhack/controller/LoginController.java
+++ b/src/main/java/org/dsmhack/controller/LoginController.java
@@ -26,9 +26,6 @@ public class LoginController {
     private static final String TOKEN_PREFIX = "Bearer ";
     private static final String HEADER_STRING = "Authorization";
 
-    @Value("${jwtSecret}")
-    private String jwtEncryptionKey;
-
     @Autowired
     private LoginService loginService;
 

--- a/src/main/java/org/dsmhack/controller/LoginController.java
+++ b/src/main/java/org/dsmhack/controller/LoginController.java
@@ -46,8 +46,8 @@ public class LoginController {
     }
     
     @PostMapping("/login")
-    public ResponseEntity<User> verifyCode(@RequestBody String securityToken) throws Exception {
-        LoginToken loginToken = loginTokenRepository.findByToken(securityToken);
+    public ResponseEntity<User> verifyCode(@RequestBody LoginToken innerToken) throws Exception {
+        LoginToken loginToken = loginTokenRepository.findByToken(innerToken.getToken());
         User user = userRepository.findOne(loginToken.getUserGuid());
         return ResponseEntity.ok().body(user);
     }

--- a/src/main/java/org/dsmhack/controller/LoginController.java
+++ b/src/main/java/org/dsmhack/controller/LoginController.java
@@ -46,9 +46,8 @@ public class LoginController {
     }
     
     @PostMapping("/login")
-    public ResponseEntity<User> verifyCode(@RequestBody LoginToken innerToken) throws Exception {
+    public User verifyCode(@RequestBody LoginToken innerToken) throws Exception {
         LoginToken loginToken = loginTokenRepository.findByToken(innerToken.getToken());
-        User user = userRepository.findOne(loginToken.getUserGuid());
-        return ResponseEntity.ok().body(user);
+        return userRepository.findOne(loginToken.getUserGuid());
     }
 }

--- a/src/main/java/org/dsmhack/controller/LoginController.java
+++ b/src/main/java/org/dsmhack/controller/LoginController.java
@@ -46,8 +46,8 @@ public class LoginController {
     }
     
     @PostMapping("/login")
-    public User verifyCode(@RequestBody LoginToken innerToken) throws Exception {
-        LoginToken loginToken = loginTokenRepository.findByToken(innerToken.getToken());
+    public User verifyCode(@RequestBody String securityToken) throws Exception {
+        LoginToken loginToken = loginTokenRepository.findByToken(securityToken);
         return userRepository.findOne(loginToken.getUserGuid());
     }
 }

--- a/src/main/java/org/dsmhack/controller/LoginController.java
+++ b/src/main/java/org/dsmhack/controller/LoginController.java
@@ -45,16 +45,10 @@ public class LoginController {
         return new ResponseEntity(HttpStatus.CREATED);
     }
     
-    @PostMapping("/login/verifyCode")
+    @PostMapping("/login")
     public ResponseEntity<User> verifyCode(@RequestBody String securityToken) throws Exception {
         LoginToken loginToken = loginTokenRepository.findByToken(securityToken);
         User user = userRepository.findOne(loginToken.getUserGuid());
-        String token = Jwts.builder()
-                .setSubject(user.getUserGuid())
-                .setExpiration(new Date(System.currentTimeMillis() + THIRTY_MINUTES))
-                .signWith(SignatureAlgorithm.HS512, jwtEncryptionKey.getBytes())
-                .compact();
-
-        return ResponseEntity.ok().header(HEADER_STRING,TOKEN_PREFIX + token).body(user);
+        return ResponseEntity.ok().body(user);
     }
 }

--- a/src/main/java/org/dsmhack/controller/ProjectController.java
+++ b/src/main/java/org/dsmhack/controller/ProjectController.java
@@ -2,12 +2,10 @@ package org.dsmhack.controller;
 
 import org.dsmhack.model.CheckIn;
 import org.dsmhack.model.Project;
-import org.dsmhack.model.User;
 import org.dsmhack.model.UserProject;
 import org.dsmhack.repository.CheckInRepository;
 import org.dsmhack.repository.ProjectRepository;
 import org.dsmhack.repository.UserProjectRepository;
-import org.dsmhack.repository.UserRepository;
 import org.dsmhack.service.CodeGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/org/dsmhack/controller/ReportController.java
+++ b/src/main/java/org/dsmhack/controller/ReportController.java
@@ -1,6 +1,5 @@
 package org.dsmhack.controller;
 
-import org.dsmhack.model.ReportData;
 import org.dsmhack.model.ReportOrganization;
 import org.dsmhack.service.ReportService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,9 +7,6 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @CrossOrigin(origins = "http://localhost:4200")
 @RestController

--- a/src/main/java/org/dsmhack/model/CheckIn.java
+++ b/src/main/java/org/dsmhack/model/CheckIn.java
@@ -15,9 +15,11 @@ package org.dsmhack.model;
 
 import com.google.gson.Gson;
 
-import javax.persistence.*;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Table

--- a/src/main/java/org/dsmhack/model/LoginToken.java
+++ b/src/main/java/org/dsmhack/model/LoginToken.java
@@ -20,7 +20,6 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Table

--- a/src/main/java/org/dsmhack/model/Organization.java
+++ b/src/main/java/org/dsmhack/model/Organization.java
@@ -21,7 +21,6 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.UUID;
 
 @Entity
 @Table

--- a/src/main/java/org/dsmhack/model/Project.java
+++ b/src/main/java/org/dsmhack/model/Project.java
@@ -22,7 +22,6 @@ import javax.persistence.Table;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @Table

--- a/src/main/java/org/dsmhack/model/ReportData.java
+++ b/src/main/java/org/dsmhack/model/ReportData.java
@@ -3,7 +3,6 @@ package org.dsmhack.model;
 import com.google.gson.Gson;
 
 import java.time.LocalDateTime;
-import java.util.UUID;
 
 public class ReportData {
     private String projectGuid;

--- a/src/main/java/org/dsmhack/model/UserOrganization.java
+++ b/src/main/java/org/dsmhack/model/UserOrganization.java
@@ -17,7 +17,6 @@ import com.google.gson.Gson;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.util.UUID;
 
 @Entity
 @Table

--- a/src/main/java/org/dsmhack/model/UserProject.java
+++ b/src/main/java/org/dsmhack/model/UserProject.java
@@ -13,13 +13,10 @@
 
 package org.dsmhack.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.gson.Gson;
 
 import javax.persistence.*;
 import java.io.Serializable;
-import java.util.Objects;
-import java.util.UUID;
 
 @Entity
 @Table

--- a/src/main/java/org/dsmhack/repository/CheckInRepository.java
+++ b/src/main/java/org/dsmhack/repository/CheckInRepository.java
@@ -1,8 +1,6 @@
 package org.dsmhack.repository;
 
 import org.dsmhack.model.CheckIn;
-import org.dsmhack.model.Project;
-import org.hibernate.annotations.Check;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,6 @@
 spring.datasource.url=jdbc:mysql://mysql:3306/heretohelp
 spring.datasource.username=root
 spring.datasource.password=password
-#spring.jpa.generate-ddl=true
-#spring.jpa.hibernate.ddl-auto=create
 flyway.baseline-on-migrate=true
-
 sendgrid.api.key=${sendgridapikey}
-jwt.secret=temporarySecretKeyToGenerateJWT
+jwt.secret=${jwtsecret}

--- a/src/main/resources/db/migration/V1_1__InsertData.sql
+++ b/src/main/resources/db/migration/V1_1__InsertData.sql
@@ -10,7 +10,7 @@ VALUES ('c84936e4-2f0f-11e8-b467-0ed5f89f718b','Community Foundation Of Des Moin
 insert into project (proj_guid,org_guid,name,description,start_date,end_date) values ('c8493824-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b','Planting Bamboo','We are planting lots of Bamboo',now(), null);
 insert into project (proj_guid,org_guid,name,description,start_date,end_date) values ('c8493950-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b','Big Hug','We are giving lots of Hugs',now(), null);
 
-insert into user (user_guid,first_name,last_name,email,role) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','Amanda','Panda','apanda@gmail.com','Organization Administrator');
+insert into user (user_guid,first_name,last_name,email,role) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','Amanda','Panda','anthonybrobston@gmail.com','Organization Administrator');
 insert into user (user_guid,first_name,last_name,email,role) values ('c84940da-2f0f-11e8-b467-0ed5f89f718b','Mike','Panda','mpanda@gmail.com','Volunteer');
 
 insert into user_organization (user_guid,org_guid) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b');

--- a/src/main/resources/db/migration/V1_1__InsertData.sql
+++ b/src/main/resources/db/migration/V1_1__InsertData.sql
@@ -10,7 +10,7 @@ VALUES ('c84936e4-2f0f-11e8-b467-0ed5f89f718b','Community Foundation Of Des Moin
 insert into project (proj_guid,org_guid,name,description,start_date,end_date) values ('c8493824-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b','Planting Bamboo','We are planting lots of Bamboo',now(), null);
 insert into project (proj_guid,org_guid,name,description,start_date,end_date) values ('c8493950-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b','Big Hug','We are giving lots of Hugs',now(), null);
 
-insert into user (user_guid,first_name,last_name,email,role) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','Amanda','Panda','anthonybrobston@gmail.com','Organization Administrator');
+insert into user (user_guid,first_name,last_name,email,role) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','Amanda','Panda','apanda@gmail.com','Organization Administrator');
 insert into user (user_guid,first_name,last_name,email,role) values ('c84940da-2f0f-11e8-b467-0ed5f89f718b','Mike','Panda','mpanda@gmail.com','Volunteer');
 
 insert into user_organization (user_guid,org_guid) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b');

--- a/src/test/java/org/dsmhack/config/AppUserDetailsServiceTest.java
+++ b/src/test/java/org/dsmhack/config/AppUserDetailsServiceTest.java
@@ -9,7 +9,6 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.security.core.userdetails.UserDetails;
 
-import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/org/dsmhack/controller/ReportControllerTest.java
+++ b/src/test/java/org/dsmhack/controller/ReportControllerTest.java
@@ -1,6 +1,5 @@
 package org.dsmhack.controller;
 
-import org.dsmhack.model.ReportData;
 import org.dsmhack.model.ReportOrganization;
 import org.dsmhack.service.ReportService;
 import org.junit.Test;
@@ -12,9 +11,9 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ReportControllerTest {

--- a/src/test/java/org/dsmhack/controller/UserControllerTest.java
+++ b/src/test/java/org/dsmhack/controller/UserControllerTest.java
@@ -1,6 +1,5 @@
 package org.dsmhack.controller;
 
-import com.google.gson.Gson;
 import org.dsmhack.model.User;
 import org.dsmhack.repository.UserRepository;
 import org.dsmhack.service.CodeGenerator;

--- a/src/test/java/org/dsmhack/service/CodeGeneratorTest.java
+++ b/src/test/java/org/dsmhack/service/CodeGeneratorTest.java
@@ -2,7 +2,8 @@ package org.dsmhack.service;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class CodeGeneratorTest {
 


### PR DESCRIPTION
This has `fix-authentication-to-swagger-ui` branch merged into it. So that should probably go first.

I finally figured out that `/login` is the correct endpoint to do auth with Spring Security. This can be modified, however I had no luck doing so. I think we would ideally like it to be `/login/sendCode`; might want to add this to tech debt; I'm keeping tech debt under issues and features under trello.

I have a small security concern around logging in using just a six digit code. I'd like to move this to use a guid; in reality the person will be clicking a link in their email, so whether it's 6 digits or a guid it shouldn't matter.

I'm moving on to Authorization (aka roles) next.