### PR TITLE
Moving to preauthorize so that we can write more intelligent authoriz…

### DIFF
--- a/src/main/java/org/dsmhack/config/WebSecurity.java
+++ b/src/main/java/org/dsmhack/config/WebSecurity.java
@@ -18,7 +18,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(securedEnabled = true)
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class WebSecurity extends WebSecurityConfigurerAdapter {
 
     @Value("${jwt.secret}")

--- a/src/main/java/org/dsmhack/controller/OrganizationController.java
+++ b/src/main/java/org/dsmhack/controller/OrganizationController.java
@@ -8,7 +8,7 @@ import org.dsmhack.service.CodeGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.annotation.Secured;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,10 +42,9 @@ public class OrganizationController {
     }
 
     @PostMapping("/organizations")
-    @Secured("ROLE_DSMHACK_ADMINISTRATOR")
+    @PreAuthorize("hasRole('ROLE_DSMHACK_ADMINISTRATOR')")
     public ResponseEntity<Organization> save(@Validated @RequestBody Organization organization) {
         organization.setOrgGuid(codeGenerator.generateUUID());
         return new ResponseEntity<>(organizationRepository.save(organization), HttpStatus.CREATED);
     }
-
 }

--- a/src/main/resources/db/migration/V1_1__InsertData.sql
+++ b/src/main/resources/db/migration/V1_1__InsertData.sql
@@ -10,14 +10,17 @@ VALUES ('c84936e4-2f0f-11e8-b467-0ed5f89f718b','Community Foundation Of Des Moin
 insert into project (proj_guid,org_guid,name,description,start_date,end_date) values ('c8493824-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b','Planting Bamboo','We are planting lots of Bamboo',now(), null);
 insert into project (proj_guid,org_guid,name,description,start_date,end_date) values ('c8493950-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b','Big Hug','We are giving lots of Hugs',now(), null);
 
-insert into user (user_guid,first_name,last_name,email,role) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','Amanda','Panda','apanda@gmail.com','ROLE_DSMHACK_ADMINISTRATOR');
-insert into user (user_guid,first_name,last_name,email,role) values ('c84940da-2f0f-11e8-b467-0ed5f89f718b','Mike','Panda','mpanda@gmail.com','ROLE_VOLUNTEER');
+insert into user (user_guid,first_name,last_name,email,role) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','Amanda','Panda','tbrobston@sourceallies.com','ROLE_DSMHACK_ADMINISTRATOR');
+insert into user (user_guid,first_name,last_name,email,role) values ('c84940da-2f0f-11e8-b467-0ed5f89f718b','Mike','Panda','anthonybrobston@live.com','ROLE_ORGANIZATION_ADMINISTRATOR');
+insert into user (user_guid,first_name,last_name,email,role) values ('c84943c4-2f0f-11e8-b467-0ed5f89f718b','Jan','Panda','anthonybrobston@gmail.com','ROLE_VOLUNTEER');
 
 insert into user_organization (user_guid,org_guid) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b');
 insert into user_organization (user_guid,org_guid) values ('c84940da-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b');
+insert into user_organization (user_guid,org_guid) values ('c84943c4-2f0f-11e8-b467-0ed5f89f718b','c849343c-2f0f-11e8-b467-0ed5f89f718b');
 
 insert into check_in (user_guid,proj_guid,time_in,time_out) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b', 'c8493824-2f0f-11e8-b467-0ed5f89f718b','2017-01-01 09:00:00', '2017-01-01 17:00:00');
 insert into check_in (user_guid,proj_guid,time_in,time_out) values ('c8493c34-2f0f-11e8-b467-0ed5f89f718b', 'c8493950-2f0f-11e8-b467-0ed5f89f718b','2017-01-01 09:00:00', '2017-01-01 15:00:00');
+insert into check_in (user_guid,proj_guid,time_in,time_out) values ('c84943c4-2f0f-11e8-b467-0ed5f89f718b', 'c8493950-2f0f-11e8-b467-0ed5f89f718b','2017-01-01 09:00:00', '2017-01-01 15:00:00');
 
 insert into check_in (user_guid,proj_guid,time_in,time_out) values ('c84940da-2f0f-11e8-b467-0ed5f89f718b', 'c8493824-2f0f-11e8-b467-0ed5f89f718b','2017-01-01 09:00:00', '2017-01-01 17:00:00');
 insert into check_in (user_guid,proj_guid,time_in,time_out) values ('c84940da-2f0f-11e8-b467-0ed5f89f718b', 'c8493824-2f0f-11e8-b467-0ed5f89f718b','2017-01-02 09:00:00', '2017-01-02 15:00:00');


### PR DESCRIPTION
I'm moving away from `@Secured` and towards `@PreAuthorize` as we can write things like this: 
```
@PreAuthorize("#username == authentication.principal.username")
public String getMyRoles(String username) {
    //...
}
```
I'm hoping we can write something for endpoints like `GET` `/organizations`. If you're a `ROLE_DSMHACK_ADMINISTRATOR` you should be able to see all Organizations. If you're a `ROLE_ORGANIZATION_ADMINISTRATOR` or `ROLE_VOLUNTEER` you should be able to see only the Organizations you belong to; this is a little harder to determine as we either have to go to the database to get the information or potentially store this information as a public claim in the `Json Web Token` and hopefully we're able to pull it out in the `PreAuthorize`, if not we'll need to come up with another solution.